### PR TITLE
Localization and translating

### DIFF
--- a/Content/Guardian/OrchidModGuardianHammer.cs
+++ b/Content/Guardian/OrchidModGuardianHammer.cs
@@ -193,7 +193,7 @@ namespace OrchidMod.Content.Guardian
 			});
 
 			string ChargeToThrow = Language.GetTextValue("Mods.OrchidMod.UI.GuardianItem.ChargeToThrow");
-			if (!CannotSwing) ChargeToThrow += Language.GetTextValue("Mods.OrchidMod.UI.GuardianItem.SwingWhileCharging");
+			if (!CannotSwing) ChargeToThrow = Language.GetTextValue("Mods.OrchidMod.UI.GuardianItem.SwingWhileCharging");
 			tooltips.Insert(index + 3, new TooltipLine(Mod, "Swing", ChargeToThrow)
 			{
 				OverrideColor = new Color(175, 255, 175)

--- a/Localization/en-US_Mods.OrchidMod.hjson
+++ b/Localization/en-US_Mods.OrchidMod.hjson
@@ -3157,19 +3157,14 @@ Items: {
 			'''
 	}
 
-	painQuarterstaff: {
-		Tooltip: ""
-		DisplayName: pain Quarterstaff
-	}
-
 	IceHammer: {
-		Tooltip: ""
 		DisplayName: Ice Hammer
+		Tooltip: ""
 	}
 
 	IceGauntlet: {
-		Tooltip: ""
 		DisplayName: Ice Gauntlet
+		Tooltip: ""
 	}
 }
 
@@ -3816,7 +3811,7 @@ UI: {
 		Parry: "{0} click to parry"
 		ParryDash: "{0} click to parry, dashing downwards"
 		ChargeToThrow: Charge to throw
-		SwingWhileCharging: ", right click to swing while charging"
+		SwingWhileCharging: Charge to throw, right click to swing while charging
 		UsesUpTo: Uses up to {0} slams
 		RuneDuration: "{0} second rune duration"
 		Block: "{0} click to block"

--- a/Localization/ru-RU_Mods.OrchidMod.hjson
+++ b/Localization/ru-RU_Mods.OrchidMod.hjson
@@ -3146,7 +3146,7 @@ Items: {
 		DisplayName: Зловещая жатва
 		Tooltip:
 			'''
-			Вместо блока выпускает косу, которая расходует 3 очка нападения застревает в первом поражённом враге
+			Вместо блока выпускает косу, которая застревает в первом поражённом враге
 			Коса даёт очки обороны по возвращению или смерти поражённого врага
 			Атаки по другим врагам заряженными бросками увеличивают количество очков обороны, которое будет получено
 			'''
@@ -3166,19 +3166,14 @@ Items: {
 			'''
 	}
 
-	painQuarterstaff: {
-		// Tooltip: ""
-		// DisplayName: pain Quarterstaff
-	}
-
 	IceHammer: {
-		// Tooltip: ""
 		// DisplayName: Ice Hammer
+		// Tooltip: ""
 	}
 
 	IceGauntlet: {
-		// Tooltip: ""
 		// DisplayName: Ice Gauntlet
+		// Tooltip: ""
 	}
 }
 
@@ -3852,19 +3847,19 @@ UI: {
 		Slam: "{0} оч. нападения"
 		Parry: Нажмите {0}, чтобы совершить парирование
 		ParryDash: Нажмите {0}, чтобы совершить парирование рывком вниз
-		ChargeToThrow:
+		ChargeToThrow: Зарядите, чтобы бросить
+		SwingWhileCharging:
 			'''
 			Зарядите, чтобы бросить
 			Нажмите ПКМ, сделать взмах во время зарядки
 			'''
-		// SwingWhileCharging: ", right click to swing while charging"
 		UsesUpTo: Использует до {0} оч. нападения
 		RuneDuration: Время действия руны: {0} сек.
 		Block: Нажмите {0}, чтобы сделать блок
-		// BlockGuard: "{0} click to block, costing {1} {^1:guard;guards}"
-		// BlockSlam: "{0} click to block, costing {1} {^1:slam;slams}"
-		// BlockGuardSlamSame: "{0} click to block, costing {1} {^1:guard;guards} and {^1:slam;slams}"
-		// BlockGuardSlam: "{0} click to block, costing {1} {^1:guard;guards} and {2} {^2:slam;slams}"
+		BlockGuard: Нажмите {0}, чтобы сделать блок за {1} оч. обороны
+		BlockSlam: Нажмите {0}, чтобы сделать блок за {1} оч. нападения
+		BlockGuardSlamSame: Нажмите {0}, чтобы сделать блок за {1} оч. обороны и нападения
+		BlockGuardSlam: Нажмите {0}, чтобы сделать блок за {1} оч. обороны и {2} оч. нападения
 		BuffDuration: Длительность эффекта: {0} сек.
 		HorizonLaceShieldStacks: Даёт 3 оч. обороны при полном заряде
 		DamageOfDefense: Наносит противостоящий урон, равный {0}% от вашей защиты


### PR DESCRIPTION
Pro tip: avoid assembling localization strings from separate parts. This can break badly in some languages. If necessary, use arguments so the components can be reordered within the text